### PR TITLE
Add GitHub Skills activity to extracurricular activities list

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This pull request adds the missing GitHub Skills activity to the school activities signup page, resolving Issue #6.

### Problem
The GitHub Skills activity announced by the principal in a school assembly was missing from the extracurricular activities list. This is time-sensitive as registrations were set to close by the end of the week.

### Solution
Added the "GitHub Skills" activity to the activities database with the following details:
- **Description:** Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications
- **Schedule:** Mondays and Wednesdays, 3:30 PM - 4:30 PM
- **Max Participants:** 25
- **Initial Participants:** Empty (ready for student signups)

### Changes
- [src/app.py](src/app.py): Added GitHub Skills activity entry to the in-memory activities dictionary

### How to Test
1. Start the application (you can use the Run and Debug feature)
2. Open the web page at localhost:8000
3. Verify that "GitHub Skills" now appears in the list of available activities
4. Students should be able to sign up for the activity

### Related Issue
Resolves #6